### PR TITLE
Adding Redux and making it play nice with React Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - [ ] [React Router](https://reacttraining.com/react-router/web/guides/philosophy)
   - [ ] Select default route
 - [X] Redux
-- [x] React + Redux
+- [x] Router + Redux
   - [X] [connected-react-router](https://github.com/supasate/connected-react-router)
 - [ ] Admin Login
   - [ ] [Mutations](https://www.apollographql.com/docs/react/essentials/mutations.html)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
   - [X] [Mocking graphql](https://www.apollographql.com/docs/graphql-tools/mocking.html)
 - [ ] [React Router](https://reacttraining.com/react-router/web/guides/philosophy)
   - [ ] Select default route
-- [ ] Redux
+- [X] Redux
+- [x] React + Redux
+  - [X] [connected-react-router](https://github.com/supasate/connected-react-router)
 - [ ] Admin Login
   - [ ] [Mutations](https://www.apollographql.com/docs/react/essentials/mutations.html)
 - [ ] CRUD Challenges
@@ -22,6 +24,11 @@
   - [ ] status (enum)
   - [ ] email
 - [ ] Polir telas
+
+
+## Warnings
+
+- [ ] Confirmar que realmente *precisamos* usar o [connected-react-router](https://github.com/supasate/connected-react-router) pra usar Router + Redux. [See commit](https://github.com/emilianoLeite/codus-crossfit-client/commit/a82d81edbba8908387b54b51b080213297913f71)
 
 _______
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "apollo-boost": "^0.1.28",
     "apollo-link-schema": "^1.1.6",
+    "connected-react-router": "^6.3.1",
     "graphql": "^14.1.1",
     "graphql-tools": "^4.0.4",
     "react": "^16.8.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,43 +1,30 @@
+import { ConnectedRouter } from "connected-react-router";
 import React from "react";
 import { ApolloProvider } from "react-apollo";
-import {
-  BrowserRouter as Router,
-  Route,
-} from "react-router-dom";
-
 import { Provider as ReduxProvider } from "react-redux";
+import { Route } from "react-router-dom";
 import { Store } from "redux";
+
 import Login from "./components/Login";
 import Navbar from "./components/Navbar";
 import PrivateRoute from "./components/PrivateRoute";
 import WipChallenges from "./components/WipChallenges";
 import client from "./graphql/client";
-import { IAuthenticator } from "./interfaces/IAuthenticator";
-
-// class Authenticator implements IAuthenticator {
-//   public isAuthenticated: boolean;
-
-//   constructor(isAuthenticated: boolean = false) {
-//     this.isAuthenticated = isAuthenticated;
-//   }
-//   public authenticate() {
-//     return new Authenticator(true);
-//   }
-// }
+import { history } from "./redux/ConfigureStore";
 
 export default class App extends React.Component<{ store: Store }, {}> {
   public render() { return (
-      <ReduxProvider store={this.props.store}>
-        <Router>
-          <ApolloProvider client={client}>
-            <Navbar />
-            <Route path="/login" component={Login}/>
-            <PrivateRoute
-              path="/challenges"
-              component={WipChallenges}
-            />
-          </ApolloProvider>
-        </Router>
-      </ReduxProvider>
+    <ReduxProvider store={this.props.store}>
+      <ConnectedRouter history={history}>
+        <ApolloProvider client={client}>
+          <Navbar />
+          <Route path="/login" component={Login} />
+          <PrivateRoute
+            path="/challenges"
+            component={WipChallenges}
+          />
+        </ApolloProvider>
+      </ConnectedRouter>
+    </ReduxProvider>
   ); }
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 
 export default () => {
   return (
-    <nav style={{ background: "#eee", padding: "5px"}}>
+    <nav>
       <Link to={`/login`}> Login </Link>
       <Link to={`/challenges`}> Challenges </Link>
     </nav>

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
 import { Redirect, Route, RouteProps } from "react-router";
-import { IAuthenticator } from "../interfaces/IAuthenticator";
 
 interface IPrivateRouteProps extends RouteProps {
   component: React.ComponentType<any>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,14 @@
+
 import React from "react";
 import ReactDOM from "react-dom";
 import { createStore } from "redux";
 import App from "./App";
 import "./index.css";
-import mainReducer from "./redux/reducers";
+import configureStore from "./redux/ConfigureStore";
 import * as serviceWorker from "./serviceWorker";
 
-const store = createStore(mainReducer, {}, (window as any).__REDUX_DEVTOOLS_EXTENSION__ &&
-  (window as any).__REDUX_DEVTOOLS_EXTENSION__());
+const store = configureStore();
+
 ReactDOM.render(<App store={store} />, document.getElementById("root"));
 
 // If you want your app to work offline and load faster, you can change

--- a/src/redux/ConfigureStore.ts
+++ b/src/redux/ConfigureStore.ts
@@ -1,0 +1,14 @@
+import { createBrowserHistory } from "history";
+import { createStore } from "redux";
+import createRootReducer from "./reducers";
+
+export const history = createBrowserHistory();
+
+export default function configureStore(preloadedState = {}) {
+  return createStore(
+   createRootReducer(history),
+   preloadedState,
+   (window as any).__REDUX_DEVTOOLS_EXTENSION__ &&
+   (window as any).__REDUX_DEVTOOLS_EXTENSION__(),
+ );
+}

--- a/src/redux/reducers/MainReducer.ts
+++ b/src/redux/reducers/MainReducer.ts
@@ -1,10 +1,17 @@
+import { connectRouter } from "connected-react-router";
+import { combineReducers } from "redux";
 import { createReducer } from "redux-starter-kit";
 import { authenticate } from "../actions";
 
-const authenticateReducer = (state: any, action: object): void => {
-  state.isAuthenticated = true;
+const authenticateReducer = (isAuthenticated: boolean, action: object): any => {
+  return true;
 };
 
-export default createReducer({ isAuthenticated: false }, {
+const mainReducer = createReducer(false, {
   [authenticate.type]: authenticateReducer,
+});
+
+export default (history: any) => combineReducers({
+  isAuthenticated: mainReducer,
+  router: connectRouter(history),
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,6 +2559,14 @@ connect-history-api-fallback@^1.3.0:
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
   integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
 
+connected-react-router@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/connected-react-router/-/connected-react-router-6.3.1.tgz#b68e505cca553ce9b6a179d4166cf43b948c85bf"
+  integrity sha512-nhuQiLOAQlCgkCypGSUhycgaqqTh2IUwVFvzw2y13v8JqB92yTk3yeAKG6X1b0IcD7S4gQizYbjgejf7DJjbyw==
+  dependencies:
+    immutable "^3.8.1"
+    seamless-immutable "^7.1.3"
+
 console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
@@ -4842,6 +4850,11 @@ immutable-tuple@^0.4.9:
   version "0.4.10"
   resolved "https://registry.yarnpkg.com/immutable-tuple/-/immutable-tuple-0.4.10.tgz#e0b1625384f514084a7a84b749a3bb26e9179929"
   integrity sha512-45jheDbc3Kr5Cw8EtDD+4woGRUV0utIrJBZT8XH0TPZRfm8tzT0/sLGGzyyCCFqFMG5Pv5Igf3WY/arn6+8V9Q==
+
+immutable@^3.8.1:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+  integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
 
 import-cwd@^2.0.0:
   version "2.1.0"
@@ -8889,6 +8902,11 @@ schema-utils@^1.0.0:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
+
+seamless-immutable@^7.1.3:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/seamless-immutable/-/seamless-immutable-7.1.4.tgz#6e9536def083ddc4dea0207d722e0e80d0f372f8"
+  integrity sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A==
 
 select-hose@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## History
First, we introduced React Router and fiddled with it. 
When we tried to implement a simple auth, we realized that a "single source of truth" was required to determine when the user was logged in. Therefore, we opted for Redux.

After installing redux, we discovered that the `PrivateRoute` comp stopped working as expected. After spending a non-trivial amount of time trying to debug it, we tried to use `connected-react-router` to solve the problem. 
As the problem disappeared, we didn't give it much though and just went with it.

In the future, it would be nice to revisit this problem to confirm if `connected-react-router` is really necessary.